### PR TITLE
Loosen Staff Regex

### DIFF
--- a/src/apps/interface/process.js
+++ b/src/apps/interface/process.js
@@ -122,7 +122,7 @@ export async function processData() {
             let uuids = []
 
             let rankMatch
-            const ranksRegex = /<strong>(?<rank>[a-zA-Z0-9]+)<\/strong>.+?(?<uuids>@(?:UUID|Compendium)\[[a-zA-Z0-9-.]+\].+?)\n/g
+            const ranksRegex = /<strong>(?<rank>[a-zA-Z0-9]+\s*)<\/strong>.+?(?<uuids>@(?:UUID|Compendium)\[[a-zA-Z0-9-.]+\].+?)\n/g
             while ((rankMatch = ranksRegex.exec(staff.description)) !== null) {
                 const rank = parseInt(rankMatch.groups.rank.trim()) || 0
 


### PR DESCRIPTION
Currently the Staff regex requires the `</strong>` to come directly after the rank text, e.g:
```html
<strong>1st</strong>
```
 While this is not a problem for already existing staff items, it can be frustrating for homebrew staves, especially for users not proficient in direct HTML editing.

This change allows text such as 

```html,
<strong>1st </strong>
```
to also be valid.